### PR TITLE
Now fully compatible with Docker

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,6 +13,10 @@
 			"Rev": "4b53e1bddba0e2f734514aeb6c02db652f4c6fe8"
 		},
 		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/config",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+		},
+		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
 			"Comment": "v0.13.0-beta-79-ga579d11",
 			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"

--- a/examples/tasks/smart-file.json
+++ b/examples/tasks/smart-file.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "5s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/disk/smart/device/sda/reallocated_sectors": {},
+        "/intel/disk/smart/device/sda/reallocated_sectors_normalized": {},
+        "/intel/disk/smart/device/sda/reserved_blocks": {},
+        "/intel/disk/smart/device/sda/reserved_blocks_normalized": {},
+        "/intel/disk/smart/device/sda/satadown_shifts": {},
+        "/intel/disk/smart/device/sda/satadown_shifts_normalized":{},
+        "/intel/disk/smart/device/sda/thermal_throttle":{},
+        "/intel/disk/smart/device/sda/thermal_throttle_event_count":{}
+      },
+      "config": {
+	"/intel/disk/smart": {
+	  "proc_path": "/proc",
+	  "dev_path": "/dev"
+	}
+      },
+      "process": null,
+      "publish": [
+          {
+              "plugin_name": "mock-file",
+              "config": {
+                  "file": "/tmp/published_smart.log"
+              }
+          }
+      ]
+    }
+  }
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,7 +35,7 @@ if [ -z "$TEST_SUITE" ]; then
 	TEST_SUITE=$1
 fi
 # Check validity
-if [ “$TEST_SUITE” != “unit” ]; then
+if [ "$TEST_SUITE" != "unit" ]; then
 	echo "Error; invalid TEST_SUITE (value must be one of 'unit'; received $TEST_SUITE)"
 	exit -1
 fi

--- a/smart/plugin.go
+++ b/smart/plugin.go
@@ -121,6 +121,9 @@ func validateName(namespace []string) bool {
 func (sc *SmartCollector) setProcDevPath(cfg interface{}) error {
 	sc.initializedMutex.Lock()
 	defer sc.initializedMutex.Unlock()
+	if sc.initialized {
+		return nil
+	}
 	procPath, err := config.GetConfigItem(cfg, "proc_path")
 	if err == nil && len(procPath.(string)) > 0 {
 		procPathStats, err := os.Stat(procPath.(string))
@@ -162,10 +165,8 @@ type smartResults map[string]interface{}
 
 // CollectMetrics returns metrics from smart
 func (sc *SmartCollector) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, error) {
-	if !sc.initialized {
-		if err := sc.setProcDevPath(mts[0]); err != nil {
-			return nil, err
-		}
+	if err := sc.setProcDevPath(mts[0]); err != nil {
+		return nil, err
 	}
 
 	buffered_results := map[string]smartResults{}
@@ -222,10 +223,8 @@ func (sc *SmartCollector) CollectMetrics(mts []plugin.MetricType) ([]plugin.Metr
 
 // GetMetricTypes returns the metric types exposed by smart
 func (sc *SmartCollector) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error) {
-	if !sc.initialized {
-		if err := sc.setProcDevPath(cfg); err != nil {
-			return nil, err
-		}
+	if err := sc.setProcDevPath(cfg); err != nil {
+		return nil, err
 	}
 	smart_metrics := ListAllKeys()
 	devices, err := sysUtilProvider.ListDevices()

--- a/smart/plugin.go
+++ b/smart/plugin.go
@@ -22,13 +22,17 @@ package smart
 import (
 	"errors"
 	"fmt"
-	"log"
+	"os"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core"
+
+	"github.com/intelsdi-x/snap-plugin-utilities/config"
 )
 
 const (
@@ -41,10 +45,17 @@ const (
 	nsType   = "smart"
 )
 
-var sysUtilProvider SysutilProvider = NewSysutilProvider()
+var (
+	//procPath source of data for metrics
+	procPath = "/proc"
+	//devPath source of data for metrics
+	devPath = "/dev"
 
-var namespace_prefix = []string{nsVendor, nsClass}
-var namespace_suffix = []string{nsType}
+	namespace_prefix = []string{nsVendor, nsClass}
+	namespace_suffix = []string{nsType}
+
+	sysUtilProvider SysutilProvider
+)
 
 func Meta() *plugin.PluginMeta {
 	return plugin.NewPluginMeta(
@@ -58,7 +69,12 @@ func Meta() *plugin.PluginMeta {
 }
 
 func NewSmartCollector() *SmartCollector {
-	return &SmartCollector{}
+	logger := log.New()
+	return &SmartCollector{
+		logger:    logger,
+		proc_path: procPath,
+		dev_path:  devPath,
+	}
 }
 
 func makeName(device, metric string) []string {
@@ -97,13 +113,52 @@ func validateName(namespace []string) bool {
 	return true
 }
 
+// Function to check properness of configuration parameters
+// and set plugin attribute accordingly
+func (sc *SmartCollector) setProcDevPath(cfg interface{}) error {
+	procPath, err := config.GetConfigItem(cfg, "proc_path")
+	if err == nil && len(procPath.(string)) > 0 {
+		procPathStats, err := os.Stat(procPath.(string))
+		if err != nil {
+			return err
+		}
+		if !procPathStats.IsDir() {
+			return errors.New(fmt.Sprintf("%s is not a directory", procPath.(string)))
+		}
+		sc.proc_path = procPath.(string)
+	}
+	devPath, err := config.GetConfigItem(cfg, "dev_path")
+	if err == nil && len(devPath.(string)) > 0 {
+		devPathStats, err := os.Stat(devPath.(string))
+		if err != nil {
+			return err
+		}
+		if !devPathStats.IsDir() {
+			return errors.New(fmt.Sprintf("%s is not a directory", devPath.(string)))
+		}
+		sc.dev_path = devPath.(string)
+	}
+	if sysUtilProvider == nil {
+		sysUtilProvider = NewSysutilProvider(sc.proc_path, sc.dev_path)
+	}
+	return nil
+}
+
 type SmartCollector struct {
+	logger    *log.Logger
+	proc_path string
+	dev_path  string
 }
 
 type smartResults map[string]interface{}
 
 // CollectMetrics returns metrics from smart
 func (sc *SmartCollector) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, error) {
+	err := sc.setProcDevPath(mts[0])
+	if err != nil {
+		return nil, err
+	}
+
 	buffered_results := map[string]smartResults{}
 
 	results := make([]plugin.MetricType, len(mts))
@@ -157,7 +212,11 @@ func (sc *SmartCollector) CollectMetrics(mts []plugin.MetricType) ([]plugin.Metr
 }
 
 // GetMetricTypes returns the metric types exposed by smart
-func (sc *SmartCollector) GetMetricTypes(_ plugin.ConfigType) ([]plugin.MetricType, error) {
+func (sc *SmartCollector) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error) {
+	err := sc.setProcDevPath(cfg)
+	if err != nil {
+		return nil, err
+	}
 	smart_metrics := ListAllKeys()
 	devices, err := sysUtilProvider.ListDevices()
 	if err != nil {
@@ -181,6 +240,8 @@ func (p *SmartCollector) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	rule, _ := cpolicy.NewStringRule("proc_path", false, "/proc")
 	node := cpolicy.NewPolicyNode()
 	node.Add(rule)
-	cp.Add([]string{nsVendor, nsClass, PluginName}, node)
+	cp.Add([]string{nsVendor, nsClass, nsType}, node)
+	rule, _ = cpolicy.NewStringRule("dev_path", false, "/dev")
+	node.Add(rule)
 	return cp, nil
 }

--- a/smart/plugin_test.go
+++ b/smart/plugin_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/intelsdi-x/snap/control/plugin"
@@ -102,8 +103,9 @@ func TestGetMetricTypes(t *testing.T) {
 			sysUtilProvider = provider
 
 			collector := SmartCollector{
-				proc_path: "/proc",
-				dev_path:  "/dev",
+				initializedMutex: new(sync.Mutex),
+				proc_path:        "/proc",
+				dev_path:         "/dev",
 			}
 
 			Convey("Both devices should be present in metric list", func() {
@@ -235,8 +237,9 @@ func TestCollectMetrics(t *testing.T) {
 		orgProvider := sysUtilProvider
 
 		sc := SmartCollector{
-			proc_path: "/proc",
-			dev_path:  "/dev",
+			initializedMutex: new(sync.Mutex),
+			proc_path:        "/proc",
+			dev_path:         "/dev",
 		}
 		cfg := cdata.NewNode()
 

--- a/smart/smart.go
+++ b/smart/smart.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -242,10 +244,12 @@ type SysutilProvider interface {
 }
 
 type sysutilProviderLinux struct {
+	proc_path string
+	dev_path  string
 }
 
 func (s *sysutilProviderLinux) OpenDevice(device string) (*os.File, error) {
-	f, err := os.OpenFile("/dev/"+device, os.O_RDWR, 0)
+	f, err := os.OpenFile(s.dev_path+"/"+device, os.O_RDWR, 0)
 	return f, err
 }
 
@@ -263,7 +267,7 @@ func (s *sysutilProviderLinux) Ioctl(fd uintptr, cmd uint, buf []byte) error {
 func (s *sysutilProviderLinux) ListDevices() ([]string, error) {
 	result := []string{}
 
-	f, err := os.Open("/proc/partitions")
+	f, err := os.Open(s.proc_path + "/partitions")
 	if err != nil {
 		return nil, err
 	}
@@ -286,6 +290,9 @@ func (s *sysutilProviderLinux) ListDevices() ([]string, error) {
 
 }
 
-func NewSysutilProvider() SysutilProvider {
-	return &sysutilProviderLinux{}
+func NewSysutilProvider(procPath string, devPath string) SysutilProvider {
+	return &sysutilProviderLinux{
+		proc_path: procPath,
+		dev_path:  devPath,
+	}
 }


### PR DESCRIPTION
You can now run this plugin within a Docker container

Note however that the container must have the [privileged mode](http://obrown.io/2016/02/15/privileged-containers.html) activated and /proc and /dev of host must be mounted as volumes in the container.

Example:

```
docker run --privileged -t -i -v /dev:/tmp/dev1 -v /proc:/tmp/proc1 
       -v $GOPATH/src/github.com/intelsdi-x/snap/build:/tmp/snap
       -v ~/SNAP-PLUGINS-4-MCP:/tmp/snap-plugins
        debian:jessie /bin/bash
```