### PR TITLE
Updated README.md and GoDep, removed mock-file from task manifests

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-smart",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GodepVersion": "v74",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -18,58 +18,58 @@
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.15.0-beta-196-ge72f01e",
+			"Rev": "e72f01e08ae255c4809b0b05fafb2f530a1e1328"
 		},
 		{
 			"ImportPath": "github.com/jtolds/gls",

--- a/README.md
+++ b/README.md
@@ -54,66 +54,66 @@ This builds the plugin in `/build/rootfs/`
 ### Collected Metrics
 This plugin has the ability to gather the following metrics:
 
-Namespace | Data Type | Description (optional)
+Namespace | Data Type | Description
 ----------|-----------|-----------------------
-/intel/disk/\<device_name\>/reallocatedsectors | | number of retired blocks
-/intel/disk/\<device_name\>/reallocatedsectors/normalized | | shows percent remaining of allowable grown defect count
-/intel/disk/\<device_name\>/poweronhours | | cumulative power-on time in hours
-/intel/disk/\<device_name\>/poweronhours/normalized | | always 100
-/intel/disk/\<device_name\>/powercyclecount | | cumulative number of power cycle events
-/intel/disk/\<device_name\>/powercyclecount/normalized | | always 100
-/intel/disk/\<device_name\>/availablereservedspace | | available reserved space
-/intel/disk/\<device_name\>/availablereservedspace/normalized | | undocumented
-/intel/disk/\<device_name\>/programfailcount | | total count of program fails
-/intel/disk/\<device_name\>/programfailcount/normalized | | percent remaining of allowable program fails
-/intel/disk/\<device_name\>/erasefailcount | | total count of erase fails
-/intel/disk/\<device_name\>/erasefailcount/percent | | remaining of allowable erase fails
-/intel/disk/\<device_name\>/unexpectedpowerloss | | cumulative number of unclean shutdowns
-/intel/disk/\<device_name\>/unexpectedpowerloss/normalized | | always 100
-/intel/disk/\<device_name\>/powerlossprotectionfailure | | last test result as microseconds to discharge capacitor
-/intel/disk/\<device_name\>/powerlossprotectionfailure/sincelast | | minutes since last test
-/intel/disk/\<device_name\>/powerlossprotectionfailure/tests | | lifetime number of tests
-/intel/disk/\<device_name\>/powerlossprotectionfailure/normalized | | 1 on test failure, 11 if capacitor tested in excessive temperature, otherwise 100
-/intel/disk/\<device_name\>/satadownshifts | | number of times SATA interface selected lower signaling rate due to error
-/intel/disk/\<device_name\>/satadownshifts/normalized | | always 100
-/intel/disk/\<device_name\>/e2eerrors | | number of LBA tag mismatches in end-to-end data protection path
-/intel/disk/\<device_name\>/e2eerrors/normalized | | always 100
-/intel/disk/\<device_name\>/uncorrectableerrors | | number of errors that could not be recovered using Error Correction Code
-/intel/disk/\<device_name\>/uncorrectableerrors/normalized | | always 100
-/intel/disk/\<device_name\>/casetemperature | | SSD case temperature in Celsius
-/intel/disk/\<device_name\>/casetemperature/min | | minimal value
-/intel/disk/\<device_name\>/casetemperature/max | | maximal value
-/intel/disk/\<device_name\>/casetemperature/overcounter | | number of times sampled temperature exceeds drive max operating temperature spec.
-/intel/disk/\<device_name\>/casetemperature/normalized | | value (100-temperature in Celsius)
-/intel/disk/\<device_name\>/unsafeshutdowns | | cumulative number of unsafe shutdowns
-/intel/disk/\<device_name\>/unsafeshutdowns/normalized | | always 100
-/intel/disk/\<device_name\>/internaltemperature | | device internal temperature in Celsius. Reading from PCB.
-/intel/disk/\<device_name\>/internaltemperature/normalized | | (150 temperature in Celsius) or 100 if temperature is less than 50.
-/intel/disk/\<device_name\>/pendingsectors | | number of current unrecoverable read errors that will be re-allocated on next write.
-/intel/disk/\<device_name\>/pendingsectors/normalized | | always 100.
-/intel/disk/\<device_name\>/crcerrors | | total number of encountered SATA CRC errors.
-/intel/disk/\<device_name\>/crcerrors/normalized | | always 100
-/intel/disk/\<device_name\>/hostwrites | | total number of sectors written by the host system
-/intel/disk/\<device_name\>/hostwrites/normalized | | always 100
-/intel/disk/\<device_name\>/timedworkload | |
-/intel/disk/\<device_name\>/timedworkload/mediawear | | measures the wear seen by the SSD (since reset of the workload timer, see timedworkload/time), as a percentage of the maximum rated cycles.
-/intel/disk/\<device_name\>/timedworkload/mediawear/normalized | | always 100
-/intel/disk/\<device_name\>/timedworkload/readpercent | | shows the percentage of I/O operations that are read operations (since reset of the workload timer, see timedworkload/time)
-/intel/disk/\<device_name\>/timedworkload/readpercent/normalized | | always 100
-/intel/disk/\<device_name\>/timedworkload/time | | number of minutes since starting workload timer
-/intel/disk/\<device_name\>/timedworkload/time/normalized | | always 100
-/intel/disk/\<device_name\>/reservedblocks | | number of reserved blocks remaining
-/intel/disk/\<device_name\>/reservedblocks/normalized | | percentage of reserved space available
-/intel/disk/\<device_name\>/wearout | | always 0
-/intel/disk/\<device_name\>/wearout/number | | of cycles the NAND media has undergone. Declines linearly from 100 to 1 as the average erase cycle count increases from 0 to the maximum rated cycles. Once it reaches 1 the number will not decrease, although it is likely that significant additional wear can be put on the device.
-/intel/disk/\<device_name\>/thermalthrottle | | percent throttle status
-/intel/disk/\<device_name\>/thermalthrottle/eventcount | | number of times thermal throttle has activated. Preserved over power cycles.
-/intel/disk/\<device_name\>/thermalthrottle/normalized | | always 100
-/intel/disk/\<device_name\>/totallba | |
-/intel/disk/\<device_name\>/totallba/written | | total number of sectors written by the host system
-/intel/disk/\<device_name\>/totallba/written/normalized | | always 100
-/intel/disk/\<device_name\>/read | | total number of sectors read by the host system
-/intel/disk/\<device_name\>/read/normalized | | always 100
+/intel/disk/smart/\<device_name\>/reallocatedsectors | | number of retired blocks
+/intel/disk/smart/\<device_name\>/reallocatedsectors/normalized | | shows percent remaining of allowable grown defect count
+/intel/disk/smart/\<device_name\>/poweronhours | | cumulative power-on time in hours
+/intel/disk/smart/\<device_name\>/poweronhours/normalized | | always 100
+/intel/disk/smart/\<device_name\>/powercyclecount | | cumulative number of power cycle events
+/intel/disk/smart/\<device_name\>/powercyclecount/normalized | | always 100
+/intel/disk/smart/\<device_name\>/availablereservedspace | | available reserved space
+/intel/disk/smart/\<device_name\>/availablereservedspace/normalized | | undocumented
+/intel/disk/smart/\<device_name\>/programfailcount | | total count of program fails
+/intel/disk/smart/\<device_name\>/programfailcount/normalized | | percent remaining of allowable program fails
+/intel/disk/smart/\<device_name\>/erasefailcount | | total count of erase fails
+/intel/disk/smart/\<device_name\>/erasefailcount/percent | | remaining of allowable erase fails
+/intel/disk/smart/\<device_name\>/unexpectedpowerloss | | cumulative number of unclean shutdowns
+/intel/disk/smart/\<device_name\>/unexpectedpowerloss/normalized | | always 100
+/intel/disk/smart/\<device_name\>/powerlossprotectionfailure | | last test result as microseconds to discharge capacitor
+/intel/disk/smart/\<device_name\>/powerlossprotectionfailure/sincelast | | minutes since last test
+/intel/disk/smart/\<device_name\>/powerlossprotectionfailure/tests | | lifetime number of tests
+/intel/disk/smart/\<device_name\>/powerlossprotectionfailure/normalized | | 1 on test failure, 11 if capacitor tested in excessive temperature, otherwise 100
+/intel/disk/smart/\<device_name\>/satadownshifts | | number of times SATA interface selected lower signaling rate due to error
+/intel/disk/smart/\<device_name\>/satadownshifts/normalized | | always 100
+/intel/disk/smart/\<device_name\>/e2eerrors | | number of LBA tag mismatches in end-to-end data protection path
+/intel/disk/smart/\<device_name\>/e2eerrors/normalized | | always 100
+/intel/disk/smart/\<device_name\>/uncorrectableerrors | | number of errors that could not be recovered using Error Correction Code
+/intel/disk/smart/\<device_name\>/uncorrectableerrors/normalized | | always 100
+/intel/disk/smart/\<device_name\>/casetemperature | | SSD case temperature in Celsius
+/intel/disk/smart/\<device_name\>/casetemperature/min | | minimal value
+/intel/disk/smart/\<device_name\>/casetemperature/max | | maximal value
+/intel/disk/smart/\<device_name\>/casetemperature/overcounter | | number of times sampled temperature exceeds drive max operating temperature spec.
+/intel/disk/smart/\<device_name\>/casetemperature/normalized | | value (100-temperature in Celsius)
+/intel/disk/smart/\<device_name\>/unsafeshutdowns | | cumulative number of unsafe shutdowns
+/intel/disk/smart/\<device_name\>/unsafeshutdowns/normalized | | always 100
+/intel/disk/smart/\<device_name\>/internaltemperature | | device internal temperature in Celsius. Reading from PCB.
+/intel/disk/smart/\<device_name\>/internaltemperature/normalized | | (150 temperature in Celsius) or 100 if temperature is less than 50.
+/intel/disk/smart/\<device_name\>/pendingsectors | | number of current unrecoverable read errors that will be re-allocated on next write.
+/intel/disk/smart/\<device_name\>/pendingsectors/normalized | | always 100.
+/intel/disk/smart/\<device_name\>/crcerrors | | total number of encountered SATA CRC errors.
+/intel/disk/smart/\<device_name\>/crcerrors/normalized | | always 100
+/intel/disk/smart/\<device_name\>/hostwrites | | total number of sectors written by the host system
+/intel/disk/smart/\<device_name\>/hostwrites/normalized | | always 100
+/intel/disk/smart/\<device_name\>/timedworkload | |
+/intel/disk/smart/\<device_name\>/timedworkload/mediawear | | measures the wear seen by the SSD (since reset of the workload timer, see timedworkload/time), as a percentage of the maximum rated cycles.
+/intel/disk/smart/\<device_name\>/timedworkload/mediawear/normalized | | always 100
+/intel/disk/smart/\<device_name\>/timedworkload/readpercent | | shows the percentage of I/O operations that are read operations (since reset of the workload timer, see timedworkload/time)
+/intel/disk/smart/\<device_name\>/timedworkload/readpercent/normalized | | always 100
+/intel/disk/smart/\<device_name\>/timedworkload/time | | number of minutes since starting workload timer
+/intel/disk/smart/\<device_name\>/timedworkload/time/normalized | | always 100
+/intel/disk/smart/\<device_name\>/reservedblocks | | number of reserved blocks remaining
+/intel/disk/smart/\<device_name\>/reservedblocks/normalized | | percentage of reserved space available
+/intel/disk/smart/\<device_name\>/wearout | | always 0
+/intel/disk/smart/\<device_name\>/wearout/number | | of cycles the NAND media has undergone. Declines linearly from 100 to 1 as the average erase cycle count increases from 0 to the maximum rated cycles. Once it reaches 1 the number will not decrease, although it is likely that significant additional wear can be put on the device.
+/intel/disk/smart/\<device_name\>/thermalthrottle | | percent throttle status
+/intel/disk/smart/\<device_name\>/thermalthrottle/eventcount | | number of times thermal throttle has activated. Preserved over power cycles.
+/intel/disk/smart/\<device_name\>/thermalthrottle/normalized | | always 100
+/intel/disk/smart/\<device_name\>/totallba | |
+/intel/disk/smart/\<device_name\>/totallba/written | | total number of sectors written by the host system
+/intel/disk/smart/\<device_name\>/totallba/written/normalized | | always 100
+/intel/disk/smart/\<device_name\>/read | | total number of sectors read by the host system
+/intel/disk/smart/\<device_name\>/read/normalized | | always 100
 
 ### Roadmap
 There isn't a current roadmap for this plugin, but it is in active development. As we launch this plugin, we do not have any outstanding requirements for the next release. If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-collector-smart/issues/new) and/or submit a [pull request](https://github.com/intelsdi-x/snap-plugin-collector-smart/pulls).

--- a/examples/tasks/smart-all-metrics-file.json
+++ b/examples/tasks/smart-all-metrics-file.json
@@ -18,7 +18,7 @@
       "process": null,
       "publish": [
           {
-              "plugin_name": "mock-file",
+              "plugin_name": "file",
               "config": {
                   "file": "/tmp/published_smart.log"
               }

--- a/examples/tasks/smart-file.json
+++ b/examples/tasks/smart-file.json
@@ -25,7 +25,7 @@
       "process": null,
       "publish": [
           {
-              "plugin_name": "mock-file",
+              "plugin_name": "file",
               "config": {
                   "file": "/tmp/published_smart.log"
               }


### PR DESCRIPTION
This pull request is continuation of https://github.com/intelsdi-x/snap-plugin-collector-smart/pull/26 which is out of date and has conflicts with master.

### Update metrics namespaces in README.md

After resolving https://github.com/intelsdi-x/snap-plugin-collector-smart/issues/19 prefix of metric namespace change, so README.md needs to be updated too.

Summary of changes:
- updated README.md
- removed "mock-file publisher" from exemplary task manifest, changed to `file publisher"
- updated godep


Testing done:
- no needed


